### PR TITLE
Remove broken links to services docs

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -71,9 +71,6 @@ breadcrumb: Cloud Foundry Documentation
         <div class="docs-link">
           <a href="/devguide/services/">Services Overview</a>
         </div>
-		 <div class="docs-link">
-	      <a href="/devguide/services/adding-a-service.html">Adding a Service</a>
-	    </div>
         <div class="docs-link">
           <a href="/devguide/services/managing-services.html">Managing Service Instances with the CLI</a>
         </div>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -132,11 +132,6 @@
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/devguide/services/adding-a-service.html">
-                    Adding a Service
-                  </a>
-                </li>
-                <li class="menu-link">
                   <a href="/devguide/services/managing-services.html">
                     Managing Service Instances with the CLI
                   </a>


### PR DESCRIPTION
Removing some links in light of the page deletion in this PR: https://github.com/cloudfoundry/docs-dev-guide/pull/48 . We made an effort to consolidate those pages to avoid duplication/inconsistency.

https://www.pivotaltracker.com/story/show/94895060