### PR TITLE
Remove the binary-buildpack link from the front page of docs site

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -147,9 +147,6 @@ breadcrumb: Cloud Foundry Documentation
         <div class="docs-link">
           <a href="/buildpacks/depend-pkg-offline.html">Packaging Dependencies for Offline Buildpacks</a>
         </div>
-        <div class="docs-link">
-          <a href="/buildpacks/binary/index.html">Binary Buildpack</a>
-        </div>
       </div>
       <h5 class="docs-landing-page-subheading">Java</h5>
       <div class="docs-column-description">


### PR DESCRIPTION
This link shouldn't be present on the main page.

#99518888]