### PR TITLE
changing location where to find our releases

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,7 @@ template_variables:
   external_ips: external IP addresses
   admin: your Cloud Foundry administrator
   api_endpoint: <a href="http://docs.cloudfoundry.org/running/cf-api-endpoint.html">the URL of the Cloud Controller in your Cloud Foundry instance</a>
-  cli_download: https://github.com/cloudfoundry/cli/releases
+  cli_download: https://github.com/cloudfoundry/cli#downloads
   console_2: If you have a Cloud Foundry account, refer to the <a href="http://docs.cloudfoundry.org/running/cf-api-endpoint.html">Indentifying the API Endpoint for your Cloud Foundry Instance</a> topic to determine the URL of the Cloud Controller in your Cloud Foundry instance. Click <strong>Manage Cloud...</strong> to add this URL to your Cloud Foundry account. Validate the account and continue through the wizard.</a>
   info_loc: In your Cloud Foundry deployment manifest
   uaa_cred: refer to the <code>uaa scim</code> section


### PR DESCRIPTION
The releases page is a GitHub generated page where all our releases (e.g. history) are stored.
We'd like users to go to the relevant section in our readme instead, which is easier to understand.