### PR TITLE
Overhaul "Deploying Cloud Foundry" stuff:

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -8,7 +8,7 @@ breadcrumb: Cloud Foundry Documentation
     <br>
     <p>
       <h1 style="margin-left: 2em; margin-bottom: 0.25em;" class="title">Get Started</h1>
-      <h1 style="margin-left: 4em; margin-top; 1em;" class="title">with</h1>      
+      <h1 style="margin-left: 4em; margin-top; 1em;" class="title">with</h1>
       <img style="width: 70%; position: relative; margin-top: 1em; margin-bottom: 1em; left: 15%; text-align: center;" src="images/new_logo_org.png">
       <h2 class="title-details" style="text-align: center; padding-top: 1.5em; padding-bottom: 0.5em; font-size: 2em;">Cloud Foundry is an open-source platform as a service, or PaaS, that provides you with a choice of clouds, developer frameworks, and application services.</p>
     </h2>
@@ -26,13 +26,13 @@ breadcrumb: Cloud Foundry Documentation
       <h3 class="title-flashy" style="padding-top: 0em; padding-left: 0em; line-height: 0.7em; margin-top: 0em;">
         <span class="title-deemph" style="font-size: 0.8em;">Participate</span><br>Contribute</h3>
     </a>
-  </li>            
+  </li>
   <li class="panel span3">
     <a class="button" href="https://www.cloudfoundry.org/learn/case-studies/">
       <h3 class="title-flashy" style="padding-top: 0em; padding-left: 0em; line-height: 0.7em; margin-top: 0em;">
         <span class="title-deemph" style="font-size: 0.8em;">Case Studies</span><br>Explore</h3>
     </a>
-  </li>            
+  </li>
 </ul>
 <div class="main docs-column-main">
   <div class="docs-subsection">
@@ -279,59 +279,24 @@ breadcrumb: Cloud Foundry Documentation
     <br>
     <div class="docs-column-description">
       <div class="docs-link">
-        <a href="/deploying/index.html">Overview</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/common/cf-release.html">Using the Latest CF-Release</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/common/network_config.html">Network Configuration</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/common/consul-security.html">Security Configuration for Consul</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/common/example_apps.html">Example Apps Deployed on CF</a>
+        <a href="/deploying/index.html">Overview of Deploying Cloud Foundry</a>
       </div>
       <br>
       <div class="docs-link">
-        <a href="/deploying/run-local.html">Run a Local Cloud Foundry Instance</a>
+        <a href="/deploying/aws/index.html">Deploying on AWS</a>
+      </div>
+      <div class="docs-link">
+        <a href="/deploying/openstack/index.html">Deploying on OpenStack</a>
+      </div>
+      <div class="docs-link">
+        <a href="/deploying/vsphere/index.html">Deploying on vSphere</a>
+      </div>
+      <div class="docs-link">
+        <a href="/deploying/vcloud/index.html">Deploying on vCloud Air or vCloud Director</a>
       </div>
       <br>
       <div class="docs-link">
-        <a href="/deploying/ec2/">Deploying to AWS</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/ec2/bootstrap-aws-vpc.html">Deploying to AWS with BOSH AWS Bootstrap</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/ec2/aws_steps.html">Deploying to AWS Tutorial</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/ec2/configure_aws_cf.html">Configuring AWS for Cloud Foundry</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/ec2/deploy_aws_cf.html">Deploying Cloud Foundry on AWS</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/ec2/cf-stub-aws.html">Customizing the Cloud Foundry Deployment Manifest Stub for AWS</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/boshlite/">Deploying Cloud Foundry to Bosh Lite on AWS</a>
-      </div>
-      <br>
-      <div class="docs-link">
-        <a href="/deploying/openstack/">Deploying to OpenStack</a>
-      </div>
-      <br>
-      <div class="docs-link">
-        <a href="/deploying/vsphere/">Deploying to vSphere</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/vcloud/">Deploying to vCloud Air or vCloud Director</a>
-      </div>
-      <div class="docs-link">
-        <a href="/deploying/vcloud/cf-stub-vcloud.html">Customizing the Cloud Foundry Deployment Manifest Stub for vCloud</a>
+        <a href="/deploying/boshlite/index.html">Deploying to a Vagrant VM with BOSH-Lite</a>
       </div>
     </div>
   </div>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -441,98 +441,140 @@
           </li>
           <li class="menu-item js-menu-item">
             <div class="menu-title js-menu-title">
-              Deploy Cloud Foundry
+               Deploying Cloud Foundry
             </div>
             <div class="menu-content js-menu-content" aria-hidden="true">
               <ul>
                 <li class="menu-link">
-                  <a href="/deploying/">
-                    Overview
+                  <a href="/deploying/index.html">
+                    Overview of Deploying Cloud Foundry
                   </a>
                 </li>
+
                 <li class="menu-link">
-                  <a href="/deploying/boshlite/">
-                    Deploying Locally with BOSH Lite
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/network_config.html">
-                    Network Configuration
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/consul-security.html">
-                    Security Configuration for Consul
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/ec2/">
-                    Deploying to AWS
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/ec2/bootstrap-aws-vpc.html">
-                    Deploying to AWS with BOSH AWS Bootstrap
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/ec2/aws_steps.html">
-                    Deploying to AWS Tutorial
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/ec2/configure_aws_cf.html">
-                    Configuring AWS for Cloud Foundry
-                  </a>
-                </li>
-                <li class="menu-link">
-                  <a href="/deploying/ec2/deploy_aws_cf.html">
+                  <a href="/deploying/aws/index.html">
                     Deploying Cloud Foundry on AWS
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/ec2/example_apps.html">
-                    Example Apps Deployed on CF
+                  <a href="/deploying/aws/setup_aws.html">
+                    Setting up an AWS Environment for Cloud Foundry with BOSH AWS Bootstrap
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="/deploying/openstack/index.html">
+                    Deploying Cloud Foundry on OpenStack
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/openstack/">
-                    Deploying to OpenStack
+                  <a href="/deploying/openstack/validate_openstack.html">
+                    Validate your OpenStack Instance
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/vsphere/">
-                    Deploying to vSphere
+                  <a href="/deploying/openstack/required-flavors.html">
+                    Required Instance Flavors for Cloud Foundry on OpenStack
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/vcloud/">
-                    Deploying to vCloud Air or vCloud Director
+                  <a href="/deploying/openstack/security_group.html">
+                    Security Group for Cloud Foundry on OpenStack
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/common/cf-release.html">
-                    Using the Latest CF-Release
+                  <a href="/deploying/openstack/set-up-dns.html">
+                    DNS Setup for Cloud Foundry on OpenStack
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="https://github.com/cloudfoundry-community/cf-services-contrib-release">
-                    Deploying Community Services
+                  <a href="/deploying/openstack/troubleshooting.html">
+                    Troubleshooting Cloud Foundry on OpenStack
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/run-local.html">
-                    Run a Local Cloud Foundry Instance
+                  <a href="/deploying/openstack/using_swift_blobstore.html">
+                    Using OpenStack Swift as a Cloud Foundry Blobstore
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="/deploying/vsphere/index.html">
+                    Deploying Cloud Foundry on vSphere
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/cf-stub-aws.html">
+                  <a href="/deploying/vsphere/hardware_spec.html">
+                    Hardware Requirements for Cloud Foundry on vSphere
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/vsphere/vcenter_user_privileges.html">
+                    Privileges Required for vCenter User
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="/deploying/vcloud/index.html">
+                    Deploying Cloud Foundry on vCloud Air or vCloud Director
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/vcloud/setup_vcloud.html">
+                    Set up vCloud Air or vCloud Virtual Data Center Resources
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="/deploying/boshlite/index.html">
+                    Deploying Cloud Foundry on BOSH-Lite
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/boshlite/create_a_manifest.html">
+                    Create a Deployment Manifest for Cloud Foundry on BOSH-Lite
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="/deploying/common/create_a_manifest.html">
+                    Create a Deployment Manifest for Cloud Foundry
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/aws/cf-stub.html">
                     Customizing the Cloud Foundry Deployment Manifest Stub for AWS
                   </a>
                 </li>
                 <li class="menu-link">
-                  <a href="/deploying/cf-stub-vcloud.html">
-                    Customizing the Cloud Foundry Deployment Manifest Stub for vCloud
+                  <a href="/deploying/openstack/cf-stub.html">
+                    Customizing the Cloud Foundry Deployment Manifest Stub for OpenStack
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/common/vsphere-vcloud-cf-stub.html">
+                    Customizing the Cloud Foundry Deployment Manifest Stub for vSphere, vCloud Air, or vCloud Director
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/common/consul-security.html">
+                    Security Configuration for Consul
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/common/deploy.html">
+                    Deploying Cloud Foundry using BOSH
+                  </a>
+                </li>
+                <li class="menu-link">
+                  <a href="/deploying/common/log_drain_blacklists.html">
+                    Log Drain Blacklist Configuration
+                  </a>
+                </li>
+
+                <li class="menu-link">
+                  <a href="https://github.com/cloudfoundry-community/cf-services-contrib-release">
+                    Deploying Community Services
                   </a>
                 </li>
               </ul>

--- a/redirects.rb
+++ b/redirects.rb
@@ -1,39 +1,33 @@
 r302 '/bosh/bosh-errands.html', '/bosh/jobs.html'
-r302 '/deploying/vsphere/cloud-foundry-example-manifest.html', '/deploying/vsphere/index.html'
-r302 '/deploying/vcloud/cloud-foundry-example-manifest.html', '/deploying/vcloud/index.html'
 r302 '/devguide/deploy-apps/api-endpoint.html', '/running/cf-api-endpoint.html'
 r302 '/console/cf-api-endpoint.html', '/running/cf-api-endpoint.html'
 r302 '/devguide/deploy-apps/sts.html', '/buildpacks/java/sts.html'
 
-r302 '/deploying/boshlite/deploy_cf_boshlite.html', '/deploying/boshlite/index.html'
-r302 '/deploying/consul-security.html', '/deploying/common/consul-security.html'
-r302 '/deploying/ec2/example_apps.html', '/deploying/common/example_apps.html'
-r302 '/deploying/network_config.html', '/deploying/common/network_config.html'
-r302 '/deploying/cf-stub-aws.html', '/deploying/ec2/cf-stub-aws.html'
-r302 '/deploying/cf-stub-openstack.html', '/deploying/openstack/cf-stub-openstack.html'
-r302 '/deploying/cf-stub-vcloud.html', '/deploying/vcloud/cf-stub-vcloud.html'
-r302 '/deploying/cf-stub-vsphere.html', '/deploying/vsphere/cf-stub-vsphere.html'
+r302 %r{/deploying/ec2/.*}, '/deploying/aws/index.html'
 
-r302 '/deploying/ec2/configure_aws_bosh.html', '/bosh/aws-cpi.html'
-r302 '/deploying/ec2/configure_aws_micro_bosh.html', '/bosh/deploy-microbosh-to-aws.html'
-r302 '/deploying/ec2/configure_aws_microbosh.html', '/bosh/deploy-microbosh-to-aws.html'
-r302 '/deploying/ec2/deploy_aws_bosh.html', '/bosh/'
-r302 '/deploying/ec2/deploy_aws_micro_bosh.html', '/deploying/ec2/deploy_aws_microbosh.html'
-r302 '/deploying/ec2/local_bosh.html', '/bosh/deploy-microbosh-to-aws.html'
-r302 '/deploying/openstack/deploying_bosh.html', '/bosh/'
-r302 '/deploying/openstack/deploying_microbosh.html', '/bosh/deploy-microbosh-to-openstack.html'
-r302 '/deploying/openstack/uploading_bosh_stemcell.html', '/bosh/deploy-microbosh-to-openstack.html'
-r302 '/deploying/vcloud/bosh-example-manifest.html', '/deploying/vcloud/index.html'
-r302 '/deploying/vcloud/deploying_bosh_with_micro_bosh.html', '/bosh/'
-r302 '/deploying/vcloud/deploying_micro_bosh.html', '/bosh/deploy_microbosh_to_vcloud.html'
-r302 '/deploying/vcloud/micro-bosh-example-manifest.html', '/deploying/vcloud/index.html'
+r302 '/deploying/openstack/deploying_bosh.html', '/deploying/openstack/index.html'
+r302 '/deploying/openstack/deploying_microbosh.html', '/deploying/openstack/index.html'
+r302 '/deploying/openstack/uploading_bosh_stemcell.html', '/deploying/openstack/index.html'
+
 r302 '/deploying/vsphere/bosh-example-manifest.html', '/deploying/vsphere/index.html'
-r302 '/deploying/vsphere/deploying_bosh_with_micro_bosh.html', '/bosh/'
-r302 '/deploying/vsphere/deploying_micro_bosh.html', '/bosh/deploy-microbosh-to-vsphere.html'
+r302 '/deploying/vsphere/deploying_bosh_with_micro_bosh.html', '/deploying/vsphere/index.html'
+r302 '/deploying/vsphere/deploying_micro_bosh.html', '/deploying/vsphere/index.html'
 r302 '/deploying/vsphere/install-and-prepare-vsphere.html', '/deploying/vsphere/index.html'
+
+r302 '/deploying/vcloud/bosh-example-manifest.html', '/deploying/vcloud/index.html'
+r302 '/deploying/vcloud/deploying_bosh_with_micro_bosh.html', '/deploying/vcloud/index.html'
+r302 '/deploying/vcloud/deploying_micro_bosh.html', '/deploying/vcloud/index.html'
+r302 '/deploying/vcloud/micro-bosh-example-manifest.html', '/deploying/vcloud/index.html'
+
+r302 '/deploying/boshlite/deploy_cf_boshlite.html', '/deploying/boshlite/index.html'
+
+r302 '/deploying/cf-stub-aws.html', '/deploying/aws/cf-stub.html'
+r302 '/deploying/cf-stub-openstack.html', '/deploying/openstack/cf-stub.html'
+r302 '/deploying/cf-stub-vsphere.html', '/deploying/common/vsphere-vcloud-cf-stub.html'
+r302 '/deploying/cf-stub-vcloud.html', '/deploying/common/vsphere-vcloud-cf-stub.html'
+
 r302 '/deploying/adding-services.html', 'https://github.com/cloudfoundry-community/cf-services-contrib-release'
+
 r302 '/services/asynchronous-operations.html', '/services/api.html#asynchronous-operations'
 
 r302 %r{/bosh/(.*)}, 'http://bosh.io/docs/$1'
-
-


### PR DESCRIPTION
- simplify links on landing page
- simplify redirection logic to mostly just send people to the correct IaaS-specific overview
- put all the things for Deploying in the sidenav