### PR TITLE
Add links for releasing_a_new_buildpack_version page

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -256,6 +256,9 @@ breadcrumb: Cloud Foundry Documentation
       <div class="docs-link">
       <a href="/buildpacks/upgrading_dependency_versions.html">Upgrading Dependency Versions</a>
       </div>
+      <div class="docs-link">
+      <a href="/buildpacks/releasing_a_new_buildpack_version.html">Releasing a New Buildpack Version</a>
+      </div>
     </div>
     <h5 class="docs-landing-page-subheading">Java</h5>
     <div class="docs-column-description">

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -416,28 +416,31 @@
           	</ul>
           </li>
           <li class="has_submenu">
-          	<a href="/buildpacks/developing-buildpacks.html">Developing Buildpacks</a>
+                <a href="/buildpacks/developing-buildpacks.html">Developing Buildpacks</a>
           	<ul>
-          		<li>
-            		<a href="/buildpacks/custom.html">Custom Buildpacks</a>
-          		</li>
-          		<li>
-            		<a href="/buildpacks/depend-pkg-offline.html">Packaging Dependencies for Offline Buildpacks</a>
-          		</li>
-          		<li>
-          			<a href="/buildpacks/merging_upstream.html">Merging from Upstream Buildpacks</a>
-          		</li>
-          		<li>
-          			<a href="/buildpacks/upgrading_dependency_versions.html">Upgrading Dependency Versions</a>
-         		</li>
+                <li>
+                  <a href="/buildpacks/custom.html">Custom Buildpacks</a>
+                </li>
+                <li>
+                  <a href="/buildpacks/depend-pkg-offline.html">Packaging Dependencies for Offline Buildpacks</a>
+                </li>
+                <li>
+                  <a href="/buildpacks/merging_upstream.html">Merging from Upstream Buildpacks</a>
+                </li>
+                <li>
+                  <a href="/buildpacks/upgrading_dependency_versions.html">Upgrading Dependency Versions</a>
+                </li>
+                <li>
+                  <a href="/buildpacks/releasing_a_new_buildpack_version.html">Releasing a New Buildpack Version</a>
+                </li>
           	</ul>
           </li>
 
-          
-          
-          
-          
-          
+
+
+
+
+
 
         </ul>
       </li>


### PR DESCRIPTION
Please only merge this in after cloudfoundry/docs-buildpacks#97 has been merged in. Thanks!

[#125637741]

Signed-off-by: Anna Thornton <athornton@pivotal.io>