### PR TITLE
Add menus for Azure

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -45,6 +45,9 @@ breadcrumb: Cloud Foundry Documentation
         <a href="/deploying/aws/index.html">Preparing to Deploy on Amazon Web Services</a>
       </div>
       <div class="docs-link">
+        <a href="/deploying/azure/index.html">Preparing to Deploy on Azure</a>
+      </div>
+      <div class="docs-link">
         <a href="/deploying/openstack/index.html">Preparing to Deploy on OpenStack</a>
       </div>
       <div class="docs-link">

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -101,6 +101,17 @@
             </ul>
           </li>
           <li class="has_submenu">
+            <a href="/deploying/azure/index.html">Preparing to Deploy on Azure</a>
+            <ul>
+              <li>
+                <a href="https://bosh.io/docs/init-azure.html">Initializing BOSH on Azure</a>
+              </li>
+              <li>
+                <a href="/deploying/azure/cf-stub.html">Customizing the Cloud Foundry Deployment Manifest for Azure</a>
+              </li>
+            </ul>
+          </li>
+          <li class="has_submenu">
             <a href="/deploying/openstack/index.html">Preparing to Deploy on OpenStack</a>
             <ul>
               <li>


### PR DESCRIPTION
Add menu for Azure. 

[PR for documents](https://github.com/cloudfoundry/docs-deploying-cf/pull/146) (which has the documents about how to prepare Azure environment) should be merged before this one. 