### PR TITLE
add volume service section to index and nav bar

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -224,6 +224,9 @@ breadcrumb: Cloud Foundry Documentation
       <div class="docs-link">
         <a href="/services/supporting-multiple-cf-instances.html">Supporting Multiple Cloud Foundry Instances</a>
       </div>
+      <div class="docs-link">
+        <a href="/services/volume-services-v2.10.html">Volume Services</a>
+      </div>
     </div>
   </div>
   <hr>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -283,6 +283,9 @@
           <li>
             <a href="/services/supporting-multiple-cf-instances.html">Supporting Multiple Cloud Foundry Instances</a>
           </li>
+          <li>
+            <a href="/services/volume-services-v2.10.html">Volume Services</a>
+          </li>
         </ul>
       </li>
       <li class="has_submenu">


### PR DESCRIPTION
We have submitted a separate PR related to this story that removes the experimental label from volume services inside the services docs.

[#130244039]

Signed-off-by: Julian Hjortshoj <julian.hjortshoj@emc.com>