### PR TITLE
Add Troubleshooting slow Requests page to Navigation

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -251,6 +251,9 @@
           <li>
             <a href="/adminguide/configure-lb-healthcheck.html">Configuring Load Balancer Healthchecks for Cloud Foundry Routers</a>
           </li>
+          <li>
+            <a href="/adminguide/troubleshooting_slow_requests.html">Troubleshooting Slow Requests in Cloud Foundry</a>
+          </li>
         </ul>
       </li>
       <li class="has_submenu">


### PR DESCRIPTION
Hi docs, 

We want to add [this](https://docs.cloudfoundry.org/adminguide/troubleshooting_slow_requests.html) page in main docs [webpage](https://docs.cloudfoundry.org/). 

Pivotal story: https://www.pivotaltracker.com/story/show/136064321

Regards
@swetharepakula && Shash