### PR TITLE
Link to CAPI library list

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -646,6 +646,9 @@
       <li class="has_submenu"><span>CAPI API</span>
         <ul>
           <li>
+            <a href="/devguide/capi/client-libraries.html">Client Libraries</a>
+          </li>
+          <li>
             <a href="http://apidocs.cloudfoundry.org">CAPI V2</a>
           </li>
           <li>


### PR DESCRIPTION
Related to cloudfoundry/api-docs#3. Adds a link to a page created by cloudfoundry/docs-dev-guide/pull/148