### PR TITLE
Drop experimental label for BBR support in CF

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -103,7 +103,7 @@
         </li>
         <li><a href="/deploying/migrating.html">Migrating from cf-release to cf-deployment</a></li>
         <li class="has_submenu">
-            <a href="/bbr/cf-backup.html">Configuring your Cloud Foundry for BOSH Backup and Restore (Experimental)</a>
+            <a href="/bbr/cf-backup.html">Configuring your Cloud Foundry for BOSH Backup and Restore</a>
             <ul>
               <li>
                 <a href="/bbr/external-blobstores.html">Backup and Restore with External Blobstores</a>


### PR DESCRIPTION
BBR is now considered a stable (opt-in) feature of the cf-deployment (https://github.com/cloudfoundry/cf-deployment/pull/442).