### PR TITLE
Fix formating: extra bullet

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -162,7 +162,12 @@ breadcrumb: Cloud Foundry Documentation
         <div class="docs-link">
           <a href="/running/cf-api-endpoint.html">Identifying your Cloud Foundry API Endpoint and Version</a>
         </div>
-        <li><a href="/devguide/custom-ports.html" class="subnav">Configuring Apps to Listen on Custom Ports</a></li>
+        <div class="docs-link">
+          <a href="/devguide/custom-ports.html" class="subnav">Configuring Apps to Listen on Custom Ports</a>
+        </div>
+        <div class="docs-link">
+          <a href="/devguide/custom-ports.html" class="subnav">Configuring Apps to Listen on Custom Ports</a>
+        </div>
       </div>
       <h5 class="docs-landing-page-subheading">Integrating Service Instances with Applications</h5>
       <div class="docs-column-description">


### PR DESCRIPTION
Fix formating: extra bullet on https://docs.cloudfoundry.org/

![image](https://user-images.githubusercontent.com/4748380/56812514-55010480-683b-11e9-8693-16c861963e67.png)
