### PR TITLE
Addd PHP CNB related subnavs

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -644,27 +644,52 @@
                 </ul>
               </li>
               <li class="has_submenu">
-                <a href="/buildpacks/php/index.html">PHP</a>
-                  <ul>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-tips.html">Tips for PHP Developers</a>
-                    </li>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-usage.html">Getting Started Deploying PHP Apps</a>
-                    </li>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-config.html">PHP Buildpack Configuration</a>
-                    </li>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-composer.html">Composer</a>
-                    </li>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-sessions.html">Sessions</a>
-                    </li>
-                    <li>
-                      <a href="/buildpacks/php/gsg-php-newrelic.html">New Relic</a>
-                    </li>
-                  </ul>
+              <span role="button">PHP</span>
+                <ul>
+                <li class="has_submenu">
+                    <a href="/buildpacks/php-cnb/index.html">PHP Cloud-Native Buildpack</a>
+                    <ul>
+                      <li>
+                        <a href="/buildpacks/php-cnb/php-usage.html">Getting Started Deploying PHP Apps</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php-cnb/php-migration.html">Migration to PHP CNB</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php-cnb/php-config.html">PHP CNB Configuration</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php-cnb/php-composer.html">Composer</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php-cnb/php-sessions.html">Sessions</a>
+                      </li>
+                    </ul>
+                  </li>
+                  <li class="has_submenu">
+                    <a href="/buildpacks/php/index.html">PHP Buildpack</a>
+                    <ul>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-tips.html">Tips for PHP Developers</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-usage.html">Getting Started Deploying PHP Apps</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-config.html">PHP Buildpack Configuration</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-composer.html">Composer</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-sessions.html">Sessions</a>
+                      </li>
+                      <li>
+                        <a href="/buildpacks/php/gsg-php-newrelic.html">New Relic</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
               </li>
               <li>
                 <a href="/buildpacks/python/index.html">Python</a>


### PR DESCRIPTION
This is the companion to https://github.com/cloudfoundry/docs-buildpacks/pull/265 that I forgot to submit earlier. This has the subnav menus for the PHP CNB additions.