### PR TITLE
Removes links to nodejs and php CNB buildpacks

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -611,80 +611,39 @@
                 <a href="/buildpacks/nginx/index.html">NGINX Buildpack</a>
               </li>
               <li class="has_submenu">
-                <span role="button">Node.js</span>
+                <a href="/buildpacks/node/index.html">Node.js</a>
                 <ul>
-                  <li class="has_submenu">
-                    <span role="button">Node.js Cloud Native Buildpack</span>
-                    <ul>
-                      <li class="">
-                        <a href="/buildpacks/nodejs-cnb/index.html">Node.js CF-compatible CNB</a>
-                      </li>
-                      <li class="">
-                        <a href="/buildpacks/nodejs-cnb/node-migration.html">Migrating to the Node.js CF-compatible CNB</a>
-                      </li>
-                    </ul>
+                  <li class="">
+                    <a href="/buildpacks/node/node-tips.html">Tips for Node.js Developers</a>
                   </li>
-                  <li class="has_submenu">
-                    <a href="/buildpacks/node/index.html">Node.js Buildpack</a>
-                    <ul>
-                      <li class="">
-                        <a href="/buildpacks/node/node-tips.html">Tips for Node.js Developers</a>
-                      </li>
-                      <li class="">
-                        <a href="/buildpacks/node/node-environment.html">Environment Variables Defined by the Node Buildpack</a>
-                      </li>
-                      <li class="">
-                        <a href="/buildpacks/node/node-service-bindings.html">Configuring Service Connections for Node.js</a>
-                      </li>
-                    </ul>
+                  <li class="">
+                    <a href="/buildpacks/node/node-environment.html">Environment Variables Defined by the Node Buildpack</a>
+                  </li>
+                  <li class="">
+                    <a href="/buildpacks/node/node-service-bindings.html">Configuring Service Connections for Node.js</a>
                   </li>
                 </ul>
               </li>
               <li class="has_submenu">
-              <span role="button">PHP</span>
+                <a href="/buildpacks/php/index.html">PHP</a>
                 <ul>
-                <li class="has_submenu">
-                    <a href="/buildpacks/php-cnb/index.html">PHP Cloud Native Buildpack</a>
-                    <ul>
-                      <li>
-                        <a href="/buildpacks/php-cnb/php-usage.html">Getting Started Deploying PHP Apps</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php-cnb/php-migration.html">Migration to PHP CNB</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php-cnb/php-config.html">PHP CNB Configuration</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php-cnb/php-composer.html">Composer</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php-cnb/php-sessions.html">Sessions</a>
-                      </li>
-                    </ul>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-tips.html">Tips for PHP Developers</a>
                   </li>
-                  <li class="has_submenu">
-                    <a href="/buildpacks/php/index.html">PHP Buildpack</a>
-                    <ul>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-tips.html">Tips for PHP Developers</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-usage.html">Getting Started Deploying PHP Apps</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-config.html">PHP Buildpack Configuration</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-composer.html">Composer</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-sessions.html">Sessions</a>
-                      </li>
-                      <li>
-                        <a href="/buildpacks/php/gsg-php-newrelic.html">New Relic</a>
-                      </li>
-                    </ul>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-usage.html">Getting Started Deploying PHP Apps</a>
+                  </li>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-config.html">PHP Buildpack Configuration</a>
+                  </li>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-composer.html">Composer</a>
+                  </li>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-sessions.html">Sessions</a>
+                  </li>
+                  <li>
+                    <a href="/buildpacks/php/gsg-php-newrelic.html">New Relic</a>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
We are no longer documenting these CNB buildpacks in the same location on the Cloud Foundry documentation. This PR removes the sidebar links. A subsequent PR will remove the content from the docs-buildpacks repo. **This PR should be merged before the content-removal PR.**