### PR TITLE
Add cf cli v7 links to sidebar and homepage

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -96,7 +96,10 @@ breadcrumb: Cloud Foundry Documentation
           <a href="/devguide/deploy-apps/start-restart-restage.html">About Starting Apps</a>
         </div>
         <div class="docs-link">
-          <a href="/cf-cli/cf-help.html">cf CLI Reference Guide</a>
+          <a href="/cf-cli/cf-help.html">cf CLI v6 Reference Guide</a>
+        </div>
+        <div class="docs-link">
+          <a href="/cf-cli/cf-help.html">cf CLI v7 Reference Guide</a>
         </div>
       </div>
     </div>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -134,7 +134,10 @@
               <a href="/cf-cli/develop-cli-plugins.html">Developing cf CLI Plugins</a>
             </li>
             <li>
-              <a href="/cf-cli/cf-help.html">cf CLI Reference Guide</a>
+              <a href="/cf-cli/cf-help.html">cf CLI v6 Reference Guide</a>
+            </li>
+            <li>
+              <a href="/cf-cli/cf7-help.html">cf CLI v7 Reference Guide</a>
             </li>
             <li>
               <a href="/devguide/v3-commands.html">Using Experimental cf CLI Commands</a>


### PR DESCRIPTION
cc @cloudfoundry/cf-cli 

- Adds a link to the recently added [cf cli v7 reference guide](https://github.com/cloudfoundry/docs-cf-cli/blob/master/cf7-help.html.md.erb) to the sidebar and hompeage.
- Renames existing cf CLI reference guide to cf CLI v6 reference guide

CF CLI story: https://www.pivotaltracker.com/story/show/174262971

**Note**
Recreated this PR without my coauthor because although coauthor is in `cloudfoundry` org on GitHub, CLA was failing. Can ignore previous PR.