### PR TITLE
Removes messaging-nats

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -87,9 +87,6 @@
               <a href="/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
             </li>
             <li class="">
-              <a href="/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-            </li>
-            <li class="">
               <a href="/concepts/architecture/router.html">Gorouter</a>
             </li>
             <li class="">


### PR DESCRIPTION
We are removing the messaging-nats page and all hyperlinks to said paid
because:
- the document does not facilitate operator/app developer understanding
and is more suited for tile developers
- the document contents are a copy-paste from the NATS docs
- information about NATS is documented elsewhere

[#174578977](https://www.pivotaltracker.com/story/show/174578977)

✨  Can you please propagate this change fro 2.7 -> master

Links to all related PRs: 
* https://github.com/cloudfoundry/docs-cloudfoundry-concepts/pull/145
* https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/102
* https://github.com/pivotal-cf/docs-book-windows/pull/2
* https://github.com/pivotal-cf/docs-ops-manager/pull/92
* https://github.com/pivotal-cf/docs-partials/pull/25
* https://github.com/pivotal-cf/docs-pas/pull/2
* https://github.com/pivotal-cf/docs-pcf-security/pull/115


cc: @jrussett