### PR TITLE
Removes Beta Feature: Dynamic Egress Policies

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -502,9 +502,6 @@
                     <li class="">
                       <a href="/devguide/deploy-apps/cf-networking.html">Configuring Container-to-Container Networking</a>
                     </li>
-                    <li class="">
-                      <a href="/devguide/egress-policies.html">Administering Dynamic Egress Policies (Beta)</a>
-                    </li>
                   </ul>
               </li>
               <li class="">


### PR DESCRIPTION
This is a beta feature introduced in 2.4 that we intend to remove for
2.11+

[#174566971](https://www.pivotaltracker.com/story/show/174566971)

cc: @jrussett 

Related PRs: 
* https://github.com/pivotal-cf/docs-partials/pull/26
* https://github.com/pivotal-cf/docs-book-windows/pull/3 
* https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/103