### PR TITLE
Fix homepage link to cf cli v7 reference guide

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -99,7 +99,7 @@ breadcrumb: Cloud Foundry Documentation
           <a href="/cf-cli/cf-help.html">cf CLI v6 Reference Guide</a>
         </div>
         <div class="docs-link">
-          <a href="/cf-cli/cf-help.html">cf CLI v7 Reference Guide</a>
+          <a href="/cf-cli/cf7-help.html">cf CLI v7 Reference Guide</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
[#174262971](https://www.pivotaltracker.com/story/show/174262971)

This corrects an issue with https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/101.

Thanks in advance!