### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/config/template_variables.yml
+++ b/config/template_variables.yml
@@ -215,7 +215,7 @@ template_variables:
   ssl_haproxy:
   garden_runc:
   tasks_ai:
-  cf_networking: For more information about how to enable and use container-to-container networking, see [Configuring Container-to-Container Networking](../devguide/deploy-apps/cf-networking.html).<p>When the container-to-container networking feature is disabled, all app-to-app traffic must go through the Gorouter. For more information, see [Gorouter](./architecture/router.html).
+  cf_networking: For more information about how to enable and use container-to-container networking, see [Configuring Container-to-Container Networking](../devguide/deploy-apps/cf-networking.html).<p>When the container-to-container networking feature is disabled, all app-to-app traffic must go through the Gorouter.
   isolation_segments_create:
   install_isolation_segments: For more information about creating isolation segments, see [Managing Isolation Segments](isolation-segments.html).
   isolation_segments_note: <p class="note"><strong>Note<span>:</span></strong> The isolation segment name used in the cf CLI command must match the value specified in the <code>placement_tags</code> section of the Diego manifest file. If the names do not match, Cloud Foundry fails to place apps in the isolation segment when apps are started or restarted in the space assigned to the isolation segment.</p>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -87,9 +87,6 @@
               <a href="/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
             </li>
             <li class="">
-              <a href="/concepts/architecture/router.html">Gorouter</a>
-            </li>
-            <li class="">
               <a href="/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
             </li>
             <li class="">


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106