### PR TITLE
Updating reference guide links for cf cli

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -96,11 +96,15 @@ breadcrumb: Cloud Foundry Documentation
           <a href="/devguide/deploy-apps/start-restart-restage.html">About Starting Apps</a>
         </div>
         <div class="docs-link">
-          <a href="/cf-cli/cf-help.html">cf CLI v6 Reference Guide</a>
+          <a href="https://cli.cloudfoundry.org/en-US/v6/">cf CLI v6 Reference Guide</a>
         </div>
         <div class="docs-link">
-          <a href="/cf-cli/cf7-help.html">cf CLI v7 Reference Guide</a>
+          <a href="https://cli.cloudfoundry.org/en-US/v7/">cf CLI v7 Reference Guide</a>
         </div>
+        <div class="docs-link">
+          <a href="https://cli.cloudfoundry.org/en-US/v8/">cf CLI v8 Reference Guide</a>
+        </div>
+
       </div>
     </div>
     <hr>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -123,11 +123,15 @@
             <a href="/cf-cli/develop-cli-plugins.html">Developing cf CLI Plugins</a>
           </li>
           <li>
-            <a href="/cf-cli/cf-help.html">cf CLI v6 Reference Guide</a>
+            <a href="https://cli.cloudfoundry.org/en-US/v6/">cf CLI v6 Reference Guide</a>
           </li>
           <li>
-            <a href="/cf-cli/cf7-help.html">cf CLI v7 Reference Guide</a>
+            <a href="https://cli.cloudfoundry.org/en-US/v7/">cf CLI v7 Reference Guide</a>
           </li>
+          <li>
+            <a href="https://cli.cloudfoundry.org/en-US/v8/">cf CLI v8 Reference Guide</a>
+          </li>
+
           <li>
             <a href="/devguide/v3-commands.html">Using Experimental cf CLI Commands</a>
           </li>


### PR DESCRIPTION
    - Pointing to cli.cloudfoundry.org docs, to remove duplication
    - Adding v8 reference guide link