### PR TITLE
Add new documentation to subnav menu

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -100,6 +100,7 @@
               <li class=""><a href="/adminguide/start-stop-vms.html">Stopping and Starting Virtual Machines</a></li>
               <li class=""><a href="/adminguide/quota-plans.html">Creating and Modifying Quota Plans</a></li>
               <li class=""><a href="/adminguide/listing-feature-flags.html">Using Feature Flags</a></li>
+              <li class=""><a href="/adminguide/using-cpu-entitlement-plugin.html">Using the CPU Entitlement Plugin</a></li>
               <li class=""><a href="/adminguide/examining_grootfs_disk.html">Examining GrootFS Disk Usage</a></li>
               <li class=""><a href="/adminguide/metadata.html">Using Metadata</a></li>
               <li class=""><a href="/adminguide/buildpacks.html">Managing Custom Buildpacks</a></li>


### PR DESCRIPTION
The [documentation](https://github.com/cloudfoundry/docs-cf-admin/blob/master/using-cpu-entitlement-plugin.html.md.erb) has already been merged