### PR TITLE
Update the process to start the preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ To submit a pull request to the documentation, follow this process:
     </pre>
    
     > **Tip:** If you run into issues with `libv8` on macOS, try following [these steps](https://gist.github.com/fernandoaleman/868b64cd60ab2d51ab24e7bf384da1ca#gistcomment-3081153) using a **non-system** version of Ruby ([`rbenv`](https://github.com/rbenv/rbenv) recommended).
-    
+    > **Tip:** If you run into issues with the installation of Ruby 2.6.8 on macOS Ventura, try following [steps](docker/README.md) and run it inside a container.   
+
     Bookbinder attempts to assemble the doc set from your local copies.
     It skips any topic repositories that you do not have checked out. For more information about Bookbinder, see the <a href="https://github.com/pivotal-cf/bookbinder#bookbinder">Bookbinder README</a>. 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.6.8-alpine3.14
+
+ARG DOCS_BOOK_CLOUDFOUNDRY_REPO=https://github.com/cloudfoundry/docs-book-cloudfoundry.git
+ARG DOCS_BOOK_CLOUDFOUNDRY_WORKDIR=/tmp/docs-book-cloudfoundry
+ARG NODEJS_VERSION=v16.9.1
+
+WORKDIR $DOCS_BOOK_CLOUDFOUNDRY_WORKDIR
+COPY files/Gemfile /tmp/Gemfile
+
+RUN cd /opt/ && wget https://nodejs.org/dist/$NODEJS_VERSION/node-$NODEJS_VERSION-linux-x64.tar.xz && \
+    tar -xf /opt/node-$NODEJS_VERSION-linux-x64.tar.xz && ln -s /opt/node-$NODEJS_VERSION-linux-x64/bin/* /usr/bin/ && \
+    apk add build-base git make g++ && cd /tmp && git clone $DOCS_BOOK_CLOUDFOUNDRY_REPO && \
+    cd $DOCS_BOOK_CLOUDFOUNDRY_WORKDIR && rm $DOCS_BOOK_CLOUDFOUNDRY_WORKDIR/Gemfile && \
+    mv /tmp/Gemfile $DOCS_BOOK_CLOUDFOUNDRY_WORKDIR/Gemfile && bundle install && \
+    rm -rf /opt/node-$NODEJS_VERSION-linux-x64.tar.xz
+
+EXPOSE 4567
+
+CMD ["bundle","exec","bookbinder","watch"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+# Ruby 2.6.8 container that includes the functionality to run the Cloudfoundry documentation webserver
+
+## Set up the Container and inject the corresponding documentation structure
+
+You can specify the injected documentation repository as mounted volume under the `/tmp` directory. The following example gives you an overview how you can specify it.
+```yaml
+    volumes:
+      - /<directory>/cf/docs-dev-guide:/tmp/docs-dev-guide
+```
+
+## Start the container via the compose file
+
+You can start the container manual oder use can also use the `docker-compose up -d` command to run it inside the daemon mode and open the documentation inside your browser under `localhost:4567`. 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  ruby-cf-bookbindery:
+    image: ruby-cf-bookbindery
+    container_name: ruby-cf-bookbindery
+    build: ../docker
+    network_mode: bridge
+    ports:
+      - "4567:4567"
+    volumes:
+      - /<directory>/cf/docs-dev-guide:/tmp/docs-dev-guide

--- a/docker/files/Gemfile
+++ b/docker/files/Gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+gem 'bookbindery', "10.1.18"
+gem 'rake'
+gem 'jasmine'
+gem 'font-awesome-sass', '4.7.0'
+gem 'haml', '~> 5.0'


### PR DESCRIPTION
Hello everyone,

with this PR, I've updated the process and documentation to run the preview mode of the documentation server at the end inside a container. 

I've faced some issues running the local server on MAC OSX 13.x and the concrete [PR](https://github.com/cloudfoundry/docs-dev-guide/pull/464#issuecomment-1322143555) and in the end, I've taken the decision to run it all together inside a container.