### PR TITLE
Fix: remove unused template_variables

### DIFF
--- a/config/template_variables.yml
+++ b/config/template_variables.yml
@@ -271,5 +271,4 @@ template_variables:
   network_policy_quota: The maximum number of policies that a Space Developer can add in a space is set by the `max_policies_per_app_source` property in the `policy-server` job in the Cloud Foundry deployment manifest. By default, the maximum is 50.
   network_policy_quota_config: To change the network policy quota for Space Developers, the Cloud Foundry operator must configure the `max_policies_per_app_source` property, then re-deploy Cloud Foundry.
   human_readable_timestamp:
-  app_rate_log_limit_config: the `max_log_lines_per_second` property in your `cf-deployment.yml` file
   find_metric_name_source_id: see [CF Component Metrics](../running/all_metrics.html) and [UAA Performance Metrics](../uaa/uaa-metrics.html)


### PR DESCRIPTION
Remove unused var related to global app log rate limiting, the (seemingly) sole usage of which was removed in https://github.com/cloudfoundry/docs-loggregator/pull/71.

cc @rroberts2222