### PR TITLE
Always prepend host when redirecting to topic homepage

### DIFF
--- a/master_middleman/source/404.html.erb
+++ b/master_middleman/source/404.html.erb
@@ -10,9 +10,6 @@ Visit the <a href="/">homepage</a>.
 Visit the <a href="" id="topic_home">homepage for this topic</a>.
 <script type="text/javascript">
 var el = document.getElementById("topic_home");
-var currentPath = window.location.pathname;
-var pathParts = currentPath.split("/");
-var partsToRemove = pathParts[pathParts.length - 1] === '' ? 2 : 1;
-pathParts.splice(-1 * partsToRemove, partsToRemove, "");
-el.setAttribute("href", pathParts.join("/"));
+var newPath = window.location.origin + window.location.pathname.replace(/\/[^/]+\/?$/, "/");
+el.setAttribute("href", newPath);
 </script>


### PR DESCRIPTION
This PR ensures that `window.location.origin` is always prepended to the `topic_home` redirection. Additionally, the logic was simplified using RegEx.