### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -624,7 +624,7 @@ breadcrumb: Cloud Foundry Documentation
           <a href="/running/rate-limit-cloud-controller-api.html">Rate limit information returned by the Cloud Controller API</a>
         </div>
         <div class="docs-link">
-          <a href="http://apidocs.cloudfoundry.org">CAPI V2 documentation</a>
+          <a href="http://v2-apidocs.cloudfoundry.org">CAPI V2 documentation</a>
         </div>
         <div class="docs-link">
           <a href="http://v3-apidocs.cloudfoundry.org/index.html">CAPI V3 documentation</a>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -388,7 +388,7 @@
         <ul>
           <li class=""><a href="/devguide/capi/client-libraries.html">Available Cloud Controller API client libraries</a></li>
           <li class=""><a href="/running/rate-limit-cloud-controller-api.html">Rate limit information returned by the Cloud Controller API</a></li>
-          <li class=""><a href="http://apidocs.cloudfoundry.org">CAPI V2</a></li>
+          <li class=""><a href="http://v2-apidocs.cloudfoundry.org">CAPI V2</a></li>
           <li class=""><a href="http://v3-apidocs.cloudfoundry.org/index.html">CAPI V3</a></li>
         </ul>
       </li>


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)