### PR TITLE
Remove links to the deprecated CLI reference docs site

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -93,15 +93,6 @@ breadcrumb: Cloud Foundry Documentation
         <div class="docs-link">
           <a href="/devguide/deploy-apps/start-restart-restage.html">About starting apps</a>
         </div>
-        <div class="docs-link">
-          <a href="https://cli.cloudfoundry.org/en-US/v6/">cf CLI v6 Reference Guide</a>
-        </div>
-        <div class="docs-link">
-          <a href="https://cli.cloudfoundry.org/en-US/v7/">cf CLI v7 Reference Guide</a>
-        </div>
-        <div class="docs-link">
-          <a href="https://cli.cloudfoundry.org/en-US/v8/">cf CLI v8 Reference Guide</a>
-        </div>
 
       </div>
     </div>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -56,9 +56,6 @@
           <li class=""><a href="/cf-cli/self-signed.html">Using the cf CLI with a self-signed certificate</a></li>
           <li class=""><a href="/cf-cli/use-cli-plugins.html">Using cf CLI plug-ins</a></li>
           <li class=""><a href="/cf-cli/develop-cli-plugins.html">Developing cf CLI plug-ins</a></li>
-          <li class=""><a href="https://cli.cloudfoundry.org/en-US/v6/">cf CLI v6 Reference Guide</a></li>
-          <li class=""><a href="https://cli.cloudfoundry.org/en-US/v7/">cf CLI v7 Reference Guide</a></li>
-          <li class=""><a href="https://cli.cloudfoundry.org/en-US/v8/">cf CLI v8 Reference Guide</a></li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
The [CLI reference docs site](https://cli.cloudfoundry.org/) has not been updated in over three years and we would like to deprecate it and make it redirect to the [CLI installation docs](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html). Since we haven't heard any complaints about the site being outdated, we don't expect this change to be an issue (if it is, please reach out to us!).

Since we're planning on doing that it no longer makes sense to link out to it from the sidebar so this PR is removing those links.