### PR TITLE
remove cpu entitlement plugin references

### DIFF
--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -99,7 +99,6 @@
               <li class=""><a href="/adminguide/start-stop-vms.html">Stopping and starting virtual machines</a></li>
               <li class=""><a href="/adminguide/quota-plans.html">Creating and modifying quota plans</a></li>
               <li class=""><a href="/adminguide/listing-feature-flags.html">Using feature flags</a></li>
-              <li class=""><a href="/adminguide/using-cpu-entitlement-plugin.html">Using the CPU entitlement plug-in</a></li>
               <li class=""><a href="/adminguide/examining_grootfs_disk.html">Examining GrootFS disk usage</a></li>
               <li class=""><a href="/adminguide/metadata.html">Using metadata</a></li>
               <li class=""><a href="/adminguide/buildpacks.html">Managing custom buildpacks</a></li>


### PR DESCRIPTION
👋 Hello!

We have deprecated the cpu entitlement plugin. I am trying to remove all references to it. I _think_ I have removed them all with this PR and [this one](https://github.com/cloudfoundry/docs-cf-admin/pull/252).