### PR TITLE
Simplify CNB structure

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -353,27 +353,15 @@ breadcrumb: Cloud Foundry Documentation
     <div class="docs-subsection">
       <h3><a class="title" href="/buildpacks/index.html">Cloud Foundry Buildpacks</a></h3>
       <div class="docs-module-description">Package the languages and libraries that support your apps.</div>
-      <h4>Cloud Native Buildpacks</h4>
+      <h4><a class="title" href="/buildpacks/cnb/index.html">Cloud Native Buildpacks</a></h4>
       <div class="docs-column-description">
-        <div class="docs-link">
-          <a href="/buildpacks/cnb/index.html">What are Cloud Native Buildpacks?</a>
-        </div>
-        <div class="docs-link">
-          <a href="/buildpacks/cnb/using.html">Using buildpacks</a>
-        </div>
-        <div class="docs-link">
-          <a href="/buildpacks/cnb/paketo.html">Paketo buildpacks</a>
-        </div>
-        <div class="docs-link">
-          <a href="/buildpacks/cnb/own.html">Developing your own buildpacks</a>
-        </div>
+      <div class="docs-link">
+        <a href="/buildpacks/cnb/understand-buildpacks.html">How Cloud Native Buildpacks work</a>
+      </div>
       </div>
 
-      <h4>Classic Buildpacks</h4>
+      <h4><a class="title" href="/buildpacks/classic.html">Classic Buildpacks</a></h4>
       <div class="docs-column-description">
-        <div class="docs-link">
-          <a href="/buildpacks/classic.html">What are Classic Buildpacks?</a>
-        </div>
         <div class="docs-link">
           <a href="/buildpacks/understand-buildpacks.html">How buildpacks work</a>
         </div>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -269,10 +269,7 @@
         <ul>
           <li class="has_submenu"><a href="/buildpacks/cnb">Cloud Native Buildpacks</a>
             <ul>
-              <li class=""><a href="/buildpacks/cnb/index.html">What are Cloud Native Buildpacks? </a></li>
-              <li class=""><a href="/buildpacks/cnb/using.html">Using buildpacks </a></li>
-              <li class=""><a href="/buildpacks/cnb/paketo.html">Paketo buildpacks </a></li>
-              <li class=""><a href="/buildpacks/cnb/own.html">Developing your own buildpacks </a></li>
+              <li class=""><a href="/buildpacks/cnb/understand-buildpacks.html">How Cloud Native Buildpacks work</a></li>
             </ul>
           </li>
 


### PR DESCRIPTION
Building on the initial documentation changes for Cloud Native Buildpacks, this change (together with https://github.com/cloudfoundry/docs-buildpacks/pull/314) brings:

- Individual entry points for Buildpacks (in general), Classic Buildpacks and Cloud Native Buildpacks
- Reduced the number of pages and merged with the front page of CNBs
- Added some tiny guidance which Buildpack variant to pick
- Added implementation differences for CNBs@CF
- Added small sample for people to try out
