### PR TITLE
Fix index page subnav for CNB

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -353,7 +353,7 @@ breadcrumb: Cloud Foundry Documentation
     <div class="docs-subsection">
       <h3><a class="title" href="/buildpacks/index.html">Cloud Foundry Buildpacks</a></h3>
       <div class="docs-module-description">Package the languages and libraries that support your apps.</div>
-      <h4><a class="title" href="/buildpacks/cnb/index.html">Cloud Native Buildpacks</a></h4>
+      <h4><a class="title" href="/buildpacks/cnb">Cloud Native Buildpacks</a></h4>
       <div class="docs-column-description">
       <div class="docs-link">
         <a href="/buildpacks/cnb/using.html">How Cloud Native Buildpacks work</a>

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -265,9 +265,9 @@
       </li>
 
 
-      <li class="has_submenu"><a href="/buildpacks/">Cloud Foundry Buildpacks</a>
+      <li class="has_submenu"><a href="/buildpacks/index.html">Cloud Foundry Buildpacks</a>
         <ul>
-          <li class="has_submenu"><a href="/buildpacks/cnb">Cloud Native Buildpacks</a>
+          <li class="has_submenu"><a href="/buildpacks/cnb/">Cloud Native Buildpacks</a>
             <ul>
               <li class=""><a href="/buildpacks/cnb/using.html">How Cloud Native Buildpacks work</a></li>
             </ul>


### PR DESCRIPTION
After opening https://docs.cloudfoundry.org/ and clicking on `Cloud Foundry Buildpacks` or `Cloud Native Buildpacks`, no entry in the sub-menu on the left is selected. This is fixed with this PR.

I noticed that links in markdown files e.g., https://github.com/cloudfoundry/docs-buildpacks/blob/741e3102aff44aba7717a2b2bf0eb1daf86294b4/index.html.md.erb#L11 always generate a link with no `.html` extension. 

Example: https://docs.cloudfoundry.org/buildpacks/index.html, link is https://docs.cloudfoundry.org/buildpacks/cnb/ instead of https://docs.cloudfoundry.org/buildpacks/cnb/index.html (as shown in the code). I guess that's how the correct entry in the sub-menu (on the left) is selected.
