### PR TITLE
fix(robots.txt): Remove `robots.txt` to enable indexing by search machines

### DIFF
--- a/master_middleman/source/robots.txt
+++ b/master_middleman/source/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
# Issue

https://docs.cloudfoundry.org/robots.txt is

```
User-agent: *
Disallow: /
```

preventing indexing by search machines.

# Fix

Looking at https://web.archive.org/web/20240000000000*/https://docs.cloudfoundry.org/robots.txt it sems like since 2014 until July 15th 2024 trying to download `robots.txt` would give you a `404` and starting August 4th 2024 the current robots.txt appeared.

As previously robots.txt was a 404 this PR removed it, restoring the previous state that worked for years.
