### PR TITLE
Remove links to canary deployments docs

### DIFF
--- a/master_middleman/source/index.html.md.erb
+++ b/master_middleman/source/index.html.md.erb
@@ -116,9 +116,6 @@ breadcrumb: Cloud Foundry Documentation
           <a href="/devguide/deploy-apps/large-app-deploy.html">Deploying your large apps</a>
         </div>
         <div class="docs-link">
-          <a href="/devguide/deploy-apps/canary-deploy.html">Configuring canary app deployments</a>
-        </div>
-        <div class="docs-link">
           <a href="/devguide/deploy-apps/rolling-deploy.html">Configuring rolling app deployments</a>
         </div>
         <div class="docs-link">

--- a/master_middleman/source/subnavs/_cf-subnav.erb
+++ b/master_middleman/source/subnavs/_cf-subnav.erb
@@ -206,7 +206,6 @@
               <li class=""><a href="/devguide/deploy-apps/start-restart-restage.html">Starting, restarting, and restaging apps</a></li>
               <li class=""><a href="/devguide/multiple-processes.html">Pushing an app with multiple processes</a></li>
               <li class=""><a href="/devguide/push-sub-commands.html">Running cf push sub-step commands</a></li>
-              <li class=""><a href="/devguide/deploy-apps/canary-deploy.html">Configuring canary app deployments</a></li>
               <li class=""><a href="/devguide/deploy-apps/rolling-deploy.html">Configuring rolling app deployments</a></li>
               <li class=""><a href="/devguide/sidecars.html">Pushing apps with sidecar processes</a></li>
               <li class=""><a href="/devguide/deploy-apps/blue-green.html">Using blue-green deployment to reduce downtime</a>


### PR DESCRIPTION
https://github.com/cloudfoundry/docs-dev-guide/pull/537